### PR TITLE
Generate MVP wasm for fuzzing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "binaryen-sys/binaryen"]
 	path = binaryen-sys/binaryen
-	url = https://github.com/pepyakin/binaryen.git
+	url = https://github.com/WebAssembly/binaryen.git

--- a/binaryen-sys/Shim.cpp
+++ b/binaryen-sys/Shim.cpp
@@ -13,7 +13,7 @@
 
 using namespace wasm;
 
-extern "C" BinaryenModuleRef translateToFuzz(const char *data, size_t len, bool emitAtomics = true) {
+extern "C" BinaryenModuleRef translateToFuzz(const char *data, size_t len, bool emitAtomics) {
     auto module = new Module();
 
     std::vector<char> input;

--- a/binaryen-sys/Shim.cpp
+++ b/binaryen-sys/Shim.cpp
@@ -8,6 +8,9 @@
 #include "tools/fuzzing.h"
 #include "binaryen-c.h"
 
+#include "wasm.h"           // For Feature enum
+#include "wasm-validator.h" // For WasmValidator
+
 using namespace wasm;
 
 extern "C" BinaryenModuleRef translateToFuzz(const char *data, size_t len) {
@@ -19,6 +22,13 @@ extern "C" BinaryenModuleRef translateToFuzz(const char *data, size_t len) {
 
     TranslateToFuzzReader reader(*module, input);
     reader.build();
+
+    // Temporary hack to avoid generating Atomics
+    if (!WasmValidator().validate(*module, (FeatureSet) Feature::MVP)) {
+        std::cerr << "Invalid module (wrt. Feature::MVP)";
+        delete module;
+        return new Module();
+    }
 
     return module;
 }

--- a/binaryen-sys/Shim.cpp
+++ b/binaryen-sys/Shim.cpp
@@ -13,7 +13,7 @@
 
 using namespace wasm;
 
-extern "C" BinaryenModuleRef translateToFuzz(const char *data, size_t len) {
+extern "C" BinaryenModuleRef translateToFuzz(const char *data, size_t len, bool emitAtomics = true) {
     auto module = new Module();
 
     std::vector<char> input;
@@ -21,14 +21,7 @@ extern "C" BinaryenModuleRef translateToFuzz(const char *data, size_t len) {
     memcpy(&input[0], data, len);
 
     TranslateToFuzzReader reader(*module, input);
-    reader.build();
-
-    // Temporary hack to avoid generating Atomics
-    if (!WasmValidator().validate(*module, (FeatureSet) Feature::MVP)) {
-        std::cerr << "Invalid module (wrt. Feature::MVP)";
-        delete module;
-        return new Module();
-    }
+    reader.build(emitAtomics);
 
     return module;
 }

--- a/binaryen-sys/src/lib.rs
+++ b/binaryen-sys/src/lib.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_void;
 
 extern "C" {
     #[no_mangle]
-    pub fn translateToFuzz(data: *const c_void, len: usize, emitAtomics:bool) -> BinaryenModuleRef;
+    pub fn translateToFuzz(data: *const c_void, len: usize, emitAtomics: bool) -> BinaryenModuleRef;
 }
 
 #[cfg(test)]

--- a/binaryen-sys/src/lib.rs
+++ b/binaryen-sys/src/lib.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_void;
 
 extern "C" {
     #[no_mangle]
-    pub fn translateToFuzz(data: *const c_void, len: usize) -> BinaryenModuleRef;
+    pub fn translateToFuzz(data: *const c_void, len: usize, emitAtomics:bool) -> BinaryenModuleRef;
 }
 
 #[cfg(test)]
@@ -21,7 +21,7 @@ mod tests {
     fn test_fuzz() {
         let vec: Vec<u8> = vec![0, 1, 2, 3, 4, 5];
         unsafe {
-            let module = translateToFuzz(vec.as_ptr() as *const c_void, vec.len());
+            let module = translateToFuzz(vec.as_ptr() as *const c_void, vec.len(), true);
             let result = BinaryenModuleValidate(module);
             assert!(result != 0);
         }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -10,8 +10,25 @@ pub fn translate_to_fuzz(seed: &[u8]) -> Module {
 
     unsafe {
         let raw_module = ffi::translateToFuzz(
-            seed.as_ptr() as *const c_void, 
-            seed.len()
+            seed.as_ptr() as *const c_void,
+            seed.len(),
+            true
+        );
+        Module::from_raw(raw_module)
+    }
+}
+
+/// Convert some random array of bytes to a WASM-MVP-only Module.
+pub fn translate_to_fuzz_mvp(seed: &[u8]) -> Module {
+    if seed.len() == 0 {
+        return Module::new();
+    }
+
+    unsafe {
+        let raw_module = ffi::translateToFuzz(
+            seed.as_ptr() as *const c_void,
+            seed.len(),
+            false
         );
         Module::from_raw(raw_module)
     }
@@ -29,8 +46,21 @@ mod tests {
             let mut rng = rand::thread_rng();
             rng.fill_bytes(&mut seed);
             let module = translate_to_fuzz(&seed);
-            
+
             assert!(module.is_valid());
         }
     }
+
+    #[test]
+    fn test_translate_to_fuzz_mvp() {
+        let mut seed = vec![0; 1000];
+        for _ in 0..1000 {
+            let mut rng = rand::thread_rng();
+            rng.fill_bytes(&mut seed);
+            let module = translate_to_fuzz(&seed);
+
+            assert!(module.is_valid());
+        }
+    }
+
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -37,6 +37,7 @@ pub fn translate_to_fuzz_mvp(seed: &[u8]) -> Module {
 #[cfg(test)]
 mod tests {
     use super::translate_to_fuzz;
+    use super::translate_to_fuzz_mvp;
     use rand::{self, Rng};
 
     #[test]
@@ -57,7 +58,7 @@ mod tests {
         for _ in 0..1000 {
             let mut rng = rand::thread_rng();
             rng.fill_bytes(&mut seed);
-            let module = translate_to_fuzz(&seed);
+            let module = translate_to_fuzz_mvp(&seed);
 
             assert!(module.is_valid());
         }


### PR DESCRIPTION
Hello,

I've developed a [cargo-fuzz WebAssembly fuzz target for cretonne](https://github.com/cretonne/cretonne/pull/306) that indirectly calls the binaryen-rs `translateToFuzz` function. Because cretonne does not support post-MVP WebAssembly functionality like atomics, I implemented a simple hack in binaryen-rs (in this PR) to restrict generation to only MVP WebAssembly. I don't think what I've done here is the correct approach, I just wanted to supply the code for reference.

Do you have any advice or guidance on how you'd like to see something like this implemented?

Thanks,
Jon