### PR TITLE
Fix signature of translateToFuzz in binaryen-sys tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ script:
   # Run tests with --test-threads=1 as it looks like the linker runs out of memory
   # when linking doctests in parallel.
   - cargo test --all --verbose -- --test-threads=1
+  - cargo test --manifest-path=binaryen-sys/Cargo.toml

--- a/binaryen-sys/src/lib.rs
+++ b/binaryen-sys/src/lib.rs
@@ -4,8 +4,6 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-use std::os::raw::c_void;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -16,7 +14,7 @@ mod tests {
     fn test_fuzz() {
         let vec: Vec<u8> = vec![0, 1, 2, 3, 4, 5];
         unsafe {
-            let module = translateToFuzz(vec.as_ptr() as *const c_void, vec.len(), true);
+            let module = translateToFuzz(vec.as_ptr() as *const i8, vec.len(), true);
             let result = BinaryenModuleValidate(module);
             assert!(result != 0);
         }


### PR DESCRIPTION
Fixes #20.

Seems like the `cargo test` in Travis is not running in sub-crate binaryen-sys.