### PR TITLE
Remove -Werror from binaryen's makefile

### DIFF
--- a/binaryen-sys/Cargo.toml
+++ b/binaryen-sys/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-
 name = "binaryen-sys"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/pepyakin/binaryen-rs"

--- a/binaryen-sys/build.rs
+++ b/binaryen-sys/build.rs
@@ -67,17 +67,35 @@ fn gen_passes() {
 
     let ids: Vec<String> = passes
         .iter()
-        .map(|pass| format!("/// {}\n{}", pass.description.to_string(), pass.id.to_string()))
+        .map(|pass| {
+            format!(
+                "/// {}\n{}",
+                pass.description.to_string(),
+                pass.id.to_string()
+            )
+        })
         .collect();
 
     let fromstrs: Vec<String> = passes
         .iter()
-        .map(|pass| format!(r#""{}" => Ok(OptimizationPass::{})"#, pass.name.to_string(), pass.id.to_string()))
+        .map(|pass| {
+            format!(
+                r#""{}" => Ok(OptimizationPass::{})"#,
+                pass.name.to_string(),
+                pass.id.to_string()
+            )
+        })
         .collect();
 
     let descriptions: Vec<String> = passes
         .iter()
-        .map(|pass| format!(r#"OptimizationPass::{} => "{}""#, pass.id.to_string(), pass.description.to_string()))
+        .map(|pass| {
+            format!(
+                r#"OptimizationPass::{} => "{}""#,
+                pass.id.to_string(),
+                pass.description.to_string()
+            )
+        })
         .collect();
 
     let output = format!(r#"
@@ -159,13 +177,17 @@ fn main() {
             .status()
             .unwrap();
 
-        println!("cargo:rustc-link-search=native={}", env::var("OUT_DIR").unwrap());
+        println!(
+            "cargo:rustc-link-search=native={}",
+            env::var("OUT_DIR").unwrap()
+        );
         println!("cargo:rustc-link-lib=static=binaryen-c");
         return;
     }
 
     let dst = cmake::Config::new("binaryen")
         .define("BUILD_STATIC_LIB", "ON")
+        .define("ENABLE_WERROR", "OFF")
         .build();
 
     println!("cargo:rustc-link-search=native={}/build/lib", dst.display());


### PR DESCRIPTION
I recommend you push this version immediately and yank `0.8.0` since `0.8.0` doesn't build on many systems.

PS: Sorry for the format changes, that was an accident because I was rushing.