### PR TITLE
Disable building binaryen tools

### DIFF
--- a/binaryen-sys/build.rs
+++ b/binaryen-sys/build.rs
@@ -137,6 +137,7 @@ fn main() {
         .define("BUILD_STATIC_LIB", "ON")
         .define("ENABLE_WERROR", "OFF")
         .define("BUILD_TESTS", "OFF")
+        .define("BUILD_TOOLS", "OFF")
         .build();
 
     println!("cargo:rustc-link-search=native={}/build/lib", dst.display());


### PR DESCRIPTION
This PR sets a CMake flag to disable building the binaryen tools, as they are not required for the crate. This cuts build time from 6m10s to 4m40s on my machine.